### PR TITLE
Add authentication and in-memory session management

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,24 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from dataclasses import dataclass
+from hashlib import pbkdf2_hmac
+import hmac
+import secrets
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+PASSWORD_HASH_ITERATIONS = 120_000
+ALLOWED_ROLES = {"student", "club_admin", "federation_admin"}
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -78,6 +88,100 @@ activities = {
 }
 
 
+class SignupRequest(BaseModel):
+    email: str = Field(min_length=3, max_length=255)
+    name: str = Field(min_length=1, max_length=100)
+    password: str = Field(min_length=8, max_length=128)
+    role: str = "student"
+
+
+class LoginRequest(BaseModel):
+    email: str = Field(min_length=3, max_length=255)
+    password: str = Field(min_length=8, max_length=128)
+
+
+@dataclass
+class User:
+    email: str
+    name: str
+    password_hash: str
+    role: str
+
+
+class SessionStore:
+    """In-memory session store that can later be swapped for persistent storage."""
+
+    def __init__(self):
+        self._sessions: dict[str, str] = {}
+
+    def create(self, email: str) -> str:
+        token = secrets.token_urlsafe(32)
+        self._sessions[token] = email
+        return token
+
+    def get_email(self, token: str) -> Optional[str]:
+        return self._sessions.get(token)
+
+    def delete(self, token: str) -> None:
+        self._sessions.pop(token, None)
+
+
+def hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    digest = pbkdf2_hmac("sha256", password.encode("utf-8"), salt, PASSWORD_HASH_ITERATIONS)
+    return f"pbkdf2_sha256${PASSWORD_HASH_ITERATIONS}${salt.hex()}${digest.hex()}"
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    algorithm, iterations_str, salt_hex, digest_hex = stored_hash.split("$")
+    if algorithm != "pbkdf2_sha256":
+        return False
+
+    derived_digest = pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        bytes.fromhex(salt_hex),
+        int(iterations_str),
+    )
+    return hmac.compare_digest(derived_digest.hex(), digest_hex)
+
+
+def user_payload(user: User) -> dict[str, str]:
+    return {
+        "email": user.email,
+        "name": user.name,
+        "role": user.role,
+    }
+
+
+def normalize_email(value: str) -> str:
+    return value.strip().lower()
+
+
+users: dict[str, User] = {}
+sessions = SessionStore()
+
+
+def require_current_user(authorization: Optional[str] = Header(default=None)) -> User:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    token = authorization.split(" ", 1)[1].strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    email = sessions.get_email(token)
+    if not email:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    user = users.get(email)
+    if not user:
+        sessions.delete(token)
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    return user
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,8 +192,66 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/signup")
+def signup(payload: SignupRequest):
+    email = normalize_email(payload.email)
+    name = payload.name.strip()
+    role = payload.role.strip().lower()
+
+    if "@" not in email:
+        raise HTTPException(status_code=400, detail="Valid email is required")
+
+    if role not in ALLOWED_ROLES:
+        raise HTTPException(status_code=400, detail="Invalid role")
+
+    if email in users:
+        raise HTTPException(status_code=409, detail="User already exists")
+
+    new_user = User(
+        email=email,
+        name=name,
+        password_hash=hash_password(payload.password),
+        role=role,
+    )
+    users[email] = new_user
+
+    token = sessions.create(email)
+    return {
+        "token": token,
+        "user": user_payload(new_user),
+    }
+
+
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    email = normalize_email(payload.email)
+    user = users.get(email)
+    if not user or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    token = sessions.create(email)
+    return {
+        "token": token,
+        "user": user_payload(user),
+    }
+
+
+@app.get("/auth/me")
+def auth_me(current_user: User = Depends(require_current_user)):
+    return {"user": user_payload(current_user)}
+
+
+@app.post("/auth/logout")
+def logout(authorization: Optional[str] = Header(default=None)):
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization.split(" ", 1)[1].strip()
+        if token:
+            sessions.delete(token)
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, current_user: User = Depends(require_current_user)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -97,6 +259,7 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    email = current_user.email
 
     # Validate student is not already signed up
     if email in activity["participants"]:
@@ -111,7 +274,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, current_user: User = Depends(require_current_user)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -119,6 +282,7 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    email = current_user.email
 
     # Validate student is signed up
     if email not in activity["participants"]:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,82 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const AUTH_TOKEN_KEY = "authToken";
+
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authForm = document.getElementById("auth-form");
+  const authNameGroup = document.getElementById("auth-name-group");
+  const authNameInput = document.getElementById("auth-name");
+  const authEmailInput = document.getElementById("auth-email");
+  const authPasswordInput = document.getElementById("auth-password");
+  const authSubmitBtn = document.getElementById("auth-submit-btn");
+  const showLoginBtn = document.getElementById("show-login");
+  const showSignupBtn = document.getElementById("show-signup");
+  const authContainer = document.getElementById("auth-container");
+  const authRequiredNote = document.getElementById("auth-required-note");
+  const signupContainer = document.getElementById("signup-container");
+  const userStatus = document.getElementById("user-status");
+  const userWelcome = document.getElementById("user-welcome");
+  const logoutBtn = document.getElementById("logout-btn");
+  const currentUserEmailInput = document.getElementById("current-user-email");
+
+  let authMode = "login";
+  let currentUser = null;
+
+  function getToken() {
+    return localStorage.getItem(AUTH_TOKEN_KEY);
+  }
+
+  function setToken(token) {
+    localStorage.setItem(AUTH_TOKEN_KEY, token);
+  }
+
+  function clearToken() {
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+  }
+
+  function setAuthMode(mode) {
+    authMode = mode;
+    authNameGroup.classList.toggle("hidden", mode !== "signup");
+    authNameInput.required = mode === "signup";
+    authSubmitBtn.textContent = mode === "signup" ? "Sign Up" : "Login";
+  }
+
+  function updateAuthUI() {
+    const isAuthenticated = Boolean(currentUser);
+    authContainer.classList.toggle("hidden", isAuthenticated);
+    signupContainer.classList.toggle("hidden", !isAuthenticated);
+    userStatus.classList.toggle("hidden", !isAuthenticated);
+    authRequiredNote.classList.toggle("hidden", isAuthenticated);
+
+    if (isAuthenticated) {
+      userWelcome.textContent = `Welcome, ${currentUser.name} (${currentUser.role})`;
+      currentUserEmailInput.value = currentUser.email;
+    } else {
+      userWelcome.textContent = "";
+      currentUserEmailInput.value = "";
+    }
+  }
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function handleUnauthorized() {
+    currentUser = null;
+    clearToken();
+    updateAuthUI();
+    authRequiredNote.classList.remove("hidden");
+    authContainer.scrollIntoView({ behavior: "smooth", block: "start" });
+    showMessage("Your session expired. Please log in again.", "error");
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +86,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +106,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        currentUser && email === currentUser.email
+                          ? `<button class="delete-btn" data-activity="${name}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -71,90 +151,173 @@ document.addEventListener("DOMContentLoaded", () => {
   async function handleUnregister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
-    const email = button.getAttribute("data-email");
+    const token = getToken();
 
     try {
-      const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
-        {
-          method: "DELETE",
-        }
-      );
+      const response = await fetch(`/activities/${encodeURIComponent(activity)}/unregister`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
+      } else if (response.status === 401) {
+        handleUnauthorized();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
+
+  async function refreshCurrentUser() {
+    const token = getToken();
+    if (!token) {
+      currentUser = null;
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        currentUser = result.user;
+      } else {
+        currentUser = null;
+        clearToken();
+      }
+    } catch (error) {
+      currentUser = null;
+      clearToken();
+      console.error("Error fetching current user:", error);
+    }
+
+    updateAuthUI();
+  }
+
+  authForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const endpoint = authMode === "signup" ? "/auth/signup" : "/auth/login";
+    const payload = {
+      email: authEmailInput.value.trim(),
+      password: authPasswordInput.value,
+    };
+
+    if (authMode === "signup") {
+      payload.name = authNameInput.value.trim();
+      payload.role = "student";
+    }
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        setToken(result.token);
+        currentUser = result.user;
+        updateAuthUI();
+        authForm.reset();
+        setAuthMode("login");
+        showMessage(authMode === "signup" ? "Account created." : "Logged in successfully.", "success");
+        fetchActivities();
+      } else {
+        showMessage(result.detail || "Authentication failed.", "error");
+      }
+    } catch (error) {
+      showMessage("Authentication request failed.", "error");
+      console.error("Authentication error:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    const token = getToken();
+
+    try {
+      if (token) {
+        await fetch("/auth/logout", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+      }
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    }
+
+    currentUser = null;
+    clearToken();
+    updateAuthUI();
+    fetchActivities();
+  });
+
+  showLoginBtn.addEventListener("click", () => {
+    setAuthMode("login");
+  });
+
+  showSignupBtn.addEventListener("click", () => {
+    setAuthMode("signup");
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
-    const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
+    const token = getToken();
 
     try {
-      const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
-        {
-          method: "POST",
-        }
-      );
+      const response = await fetch(`/activities/${encodeURIComponent(activity)}/signup`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
+      } else if (response.status === 401) {
+        handleUnauthorized();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  setAuthMode("login");
+
   // Initialize app
-  fetchActivities();
+  refreshCurrentUser().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,9 +10,39 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="user-status" class="hidden">
+        <span id="user-welcome"></span>
+        <button id="logout-btn" type="button">Log Out</button>
+      </div>
     </header>
 
     <main>
+      <section id="auth-container">
+        <h3>Login or Sign Up</h3>
+        <p id="auth-required-note" class="info hidden">Please log in to register for activities.</p>
+
+        <div class="auth-switch">
+          <button id="show-login" type="button" class="secondary-btn">Login</button>
+          <button id="show-signup" type="button" class="secondary-btn">Sign Up</button>
+        </div>
+
+        <form id="auth-form">
+          <div class="form-group">
+            <label for="auth-email">Email:</label>
+            <input type="email" id="auth-email" required placeholder="your-email@mergington.edu" />
+          </div>
+          <div class="form-group hidden" id="auth-name-group">
+            <label for="auth-name">Name:</label>
+            <input type="text" id="auth-name" placeholder="Your name" />
+          </div>
+          <div class="form-group">
+            <label for="auth-password">Password:</label>
+            <input type="password" id="auth-password" required minlength="8" />
+          </div>
+          <button type="submit" id="auth-submit-btn">Login</button>
+        </form>
+      </section>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">
@@ -25,8 +55,8 @@
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">
-            <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
+            <label for="current-user-email">Logged in as:</label>
+            <input type="text" id="current-user-email" disabled />
           </div>
           <div class="form-group">
             <label for="activity">Select Activity:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,15 @@ header h1 {
   margin-bottom: 10px;
 }
 
+#user-status {
+  margin-top: 12px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;
@@ -147,6 +156,21 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 16px;
+}
+
+.auth-switch {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.secondary-btn {
+  background-color: #e8eaf6;
+  color: #1a237e;
+}
+
+.secondary-btn:hover {
+  background-color: #c5cae9;
 }
 
 button {


### PR DESCRIPTION
Implements issue #8 by adding backend authentication/session APIs and frontend authenticated state handling.

## What changed
- Added user model with fields: email, name, password hash, role
- Added password hashing using PBKDF2-HMAC-SHA256 (no plaintext passwords)
- Added in-memory session store with bearer tokens
- Added auth endpoints:
  - `POST /auth/signup`
  - `POST /auth/login`
  - `GET /auth/me`
  - `POST /auth/logout`
- Protected activity mutation endpoints so they require authentication:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Updated frontend with login/signup UI, logout, token persistence, and redirect-to-login behavior when protected actions return 401
- Kept activity listing public to preserve existing browsing behavior

## Validation
- `python -m compileall src/app.py`
- Manual API checks:
  - unauthenticated `GET /auth/me` returns 401
  - signup/login flow returns token and user payload
  - authenticated activity signup works
  - logout invalidates session
  - protected activity signup returns 401 when not authenticated
  - public `GET /activities` remains 200